### PR TITLE
Handle missing texture number layer when assigning textures

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -2588,9 +2588,11 @@ class MaterialAssignmentAuto(bpy.types.Operator):
 
         texnum_layer = bm.faces.layers.int.get("Texture Number")
         if not texnum_layer:
-            bm.free()
-            print(f"[SKIP] No 'Texture Number' layer on {obj.name}")
-            return
+            # Create the layer so we can still assign a sensible default texture
+            texnum_layer = bm.faces.layers.int.new("Texture Number")
+            for face in bm.faces:
+                face[texnum_layer] = 0
+            print(f"[INFO] Created missing 'Texture Number' layer on {obj.name} with default 0")
 
         scene = bpy.context.scene
         base_name = ""


### PR DESCRIPTION
## Summary
- create a missing "Texture Number" layer when assigning UV textures automatically
- default new faces to texture index 0 so texture materials can be applied

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923717008c88333b076a12e217cbb89)