### PR TITLE
Ensure car texture selection persists during import

### DIFF
--- a/prm_in.py
+++ b/prm_in.py
@@ -13,7 +13,15 @@ from mathutils import Vector
 from . import common
 from . import rvstruct
 from .rvstruct import PRM
-from .common import to_blender_coord, to_blender_axis, FACE_QUAD, reverse_quad, FACE_ENV, dprint
+from .common import (
+    to_blender_coord,
+    to_blender_axis,
+    FACE_QUAD,
+    reverse_quad,
+    FACE_ENV,
+    dprint,
+    set_scene_value,
+)
 
 def import_file(filepath, scene):
     """
@@ -115,6 +123,8 @@ def add_rvmesh_to_bmesh(prm, bm, me, filepath, scene, envlist=None):
                     tex_image.image = image
                     material.node_tree.links.new(bsdf.inputs['Base Color'], tex_image.outputs['Color'])
                     print(f"Created new material: {material_name}")
+                set_scene_value(scene, "selected_car_texture", material_name)
+
                 if material_name not in me.materials:
                     me.materials.append(material)
                     print(f"Added material to mesh: {material_name}")
@@ -133,6 +143,8 @@ def add_rvmesh_to_bmesh(prm, bm, me, filepath, scene, envlist=None):
                         tex_image.image = car_texture
                         material.node_tree.links.new(bsdf.inputs['Base Color'], tex_image.outputs['Color'])
                         print(f"Created fallback material: {material_name}")
+                    set_scene_value(scene, "selected_car_texture", material_name)
+
                     if material_name not in me.materials:
                         me.materials.append(material)
                         print(f"Added fallback material to mesh: {material_name}")


### PR DESCRIPTION
## Summary
- record the resolved car texture name in the scene when importing PRM meshes
- update both primary and fallback car material creation to keep selected skin available for later assignment

## Testing
- Not run (Blender not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237404d0b88333a8317a6ea2212be3)