### PR TITLE
Speed up FIN import by batching COL material assignment

### DIFF
--- a/fin_in.py
+++ b/fin_in.py
@@ -55,6 +55,8 @@ def import_file(filepath, scene, texture_base_name=None):
         print(f"Importing instance {idx + 1}/{len(fin.instances)}: {instance.name}")
         import_instance(filepath, scene, instance, texture_base_name, mesh_cache, name_counter)
 
+    print("Assigning vertex color materials...")
+    assign_col_materials(scene)
     print("Assigning UV texture materials...")
     assign_uvtex_materials(scene)
     print("Import complete.")
@@ -157,8 +159,6 @@ def import_instance(filepath, scene, instance, texture_base_name, mesh_cache, na
     # If mesh exists, set model color material & COL materials
     if instance_obj.data:
         model_color_material(instance_obj)
-        print("Assigning vertex color materials...")
-        assign_col_materials(scene)
 
     print(f"Finished importing {unique_name}")
     return instance_obj


### PR DESCRIPTION
## Summary
- run COL material assignment once after all FIN instances are imported
- reduce repeated material selection work during FIN import to improve performance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237c3614c48333b492c4f87da50538)