### PR TITLE
Handle material assignment for long base names

### DIFF
--- a/common.py
+++ b/common.py
@@ -740,18 +740,18 @@ def get_format(fstr):
 def get_model_materials(self, context):
 	return [(mat.name, mat.name, "") for mat in bpy.data.materials if mat.name.lower().endswith('.bmp')]
 
-def clean_model_base_name(name):
-	"""
-	Cleans model base name:
-	- Lowercases
-	- Strips .001 / _01 suffixes
-	- Strips file extensions like .prm, .m, .w, .bmp
-	- Truncates to max 8 characters
-	"""
-	name = name.lower()
-	name = re.sub(r'[\._-]\d+$', '', name)
-	name = re.sub(r'\.(prm|m|w|bmp)$', '', name)
-	return name[:8]
+def clean_model_base_name(name, *, truncate=True):
+        """
+        Cleans model base name:
+        - Lowercases
+        - Strips .001 / _01 suffixes
+        - Strips file extensions like .prm, .m, .w, .bmp
+        - Optionally truncates to max 8 characters (default: True)
+        """
+        name = name.lower()
+        name = re.sub(r'[\._-]\d+$', '', name)
+        name = re.sub(r'\.(prm|m|w|bmp)$', '', name)
+        return name[:8] if truncate else name
 
 def texnum_to_label(index):
     if index < 26:

--- a/operators.py
+++ b/operators.py
@@ -2911,7 +2911,7 @@ class MaterialAssignmentAuto(bpy.types.Operator):
     def assign_regular_materials(self, obj, material_suffix):
         print(f"[FAST] assign_regular_materials: {obj.name}")
 
-        base_name = clean_model_base_name(obj.name)
+        base_name = clean_model_base_name(obj.name, truncate=False)
         potential_names = [
             f"{base_name}{material_suffix}",
             f"{base_name}.prm{material_suffix}",
@@ -3208,7 +3208,7 @@ class MaterialAssignment(bpy.types.Operator):
         obj.data.update()
 
     def assign_regular_materials(self, obj, material_suffix):
-        base_name = clean_model_base_name(obj.name)
+        base_name = clean_model_base_name(obj.name, truncate=False)
 
         potential_names = [
             f"{base_name}{material_suffix}",
@@ -3526,7 +3526,7 @@ class MaterialAssignmentImportExport(bpy.types.Operator):
         obj.data.update()
 
     def assign_regular_materials(self, obj, material_suffix):
-        base_name = clean_model_base_name(obj.name)
+        base_name = clean_model_base_name(obj.name, truncate=False)
 
         potential_names = [
             f"{base_name}{material_suffix}",


### PR DESCRIPTION
## Summary
- add an optional truncate flag to `clean_model_base_name` so callers can preserve full model names when needed
- use non-truncated base names when resolving regular materials, allowing .w/.m objects to find suffix materials like _Col/_Alpha/_Env

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692380793cf88333a87eedb343b231a2)