### PR TITLE
Use Tex+VC+Alpha preview after imports

### DIFF
--- a/fin_in.py
+++ b/fin_in.py
@@ -57,8 +57,8 @@ def import_file(filepath, scene, texture_base_name=None):
 
     print("Assigning vertex color materials...")
     assign_col_materials(scene)
-    print("Assigning UV texture materials...")
-    assign_uvtex_materials(scene)
+    print("Assigning Tex+VC+Alpha materials...")
+    assign_texvc_materials(scene)
     print("Import complete.")
 
 # ---------------------------------------------------------------------------
@@ -411,3 +411,25 @@ def assign_uvtex_materials(scene):
         bm.free()
 
         obj["material_assigned_uv"] = True
+
+
+def assign_texvc_materials(scene):
+    """Assign Tex+VC+Alpha materials to all mesh objects after import."""
+
+    mesh_objects = [obj for obj in scene.objects if obj.type == 'MESH' and obj.data]
+    if not mesh_objects:
+        return
+
+    bpy.ops.object.select_all(action='DESELECT')
+
+    scene.material_choice = 'TEX_VC'
+
+    for obj in mesh_objects:
+        obj.select_set(True)
+
+    bpy.context.view_layer.objects.active = mesh_objects[0]
+
+    if bpy.context.object and bpy.context.object.mode != 'OBJECT':
+        bpy.ops.object.mode_set(mode='OBJECT')
+
+    bpy.ops.object.assign_materials_impexp()

--- a/m_in.py
+++ b/m_in.py
@@ -100,12 +100,12 @@ def import_file(filepath, scene, model_name=None):
         else:
             print("[WARN] Scene has no 'material_choice' property; COL assignment skipped.")
 
-        # 2) Assign UV_TEX materials using Scene-level material_choice
+        # 2) Assign Tex+VC+Alpha materials using Scene-level material_choice
         if hasattr(scene, "material_choice"):
-            scene.material_choice = 'UV_TEX'
+            scene.material_choice = 'TEX_VC'
             bpy.ops.object.assign_materials_impexp()
         else:
-            print("[WARN] Scene has no 'material_choice' property; UV_TEX assignment skipped.")
+            print("[WARN] Scene has no 'material_choice' property; TEX_VC assignment skipped.")
 
     return obj
 

--- a/prm_in.py
+++ b/prm_in.py
@@ -60,7 +60,7 @@ def import_file(filepath, scene):
             bpy.context.scene.collection.objects.link(obj)
             bpy.context.view_layer.objects.active = obj
             set_material_to_prm_col([obj])  # First assign COL
-            assign_uv_tex_material(obj, filepath)  # Then assign UV_TEX
+            assign_uv_tex_material(obj, filepath)  # Then assign TEX_VC
 
             mesh_objects = [obj for obj in scene.objects if obj.type == 'MESH']
             set_material_to_prm_texture(mesh_objects)
@@ -221,13 +221,13 @@ def assign_uv_tex_material(obj, filepath):
     obj.data.update()
 
 def set_material_to_prm_texture(mesh_objects):
-    """Sets the material to Texture (UV_TEX) for all mesh objects."""
+    """Sets the material to Texture + Vertex Colour + Alpha (TEX_VC) for all mesh objects."""
     if not mesh_objects:
         print("No mesh objects selected for material assignment.")
         return
 
     scene = bpy.context.scene
-    scene.material_choice = 'UV_TEX'  # <-- now on Scene
+    scene.material_choice = 'TEX_VC'  # <-- now on Scene
 
     # Select only the meshes we care about
     bpy.ops.object.select_all(action='DESELECT')

--- a/w_in.py
+++ b/w_in.py
@@ -190,8 +190,8 @@ def fast_batch_assign_materials(scene):
     # Assign Vertex Color materials (COL) first
     fast_batch_assign_material_choice(scene, mesh_objects, 'COL')
 
-    # Then assign UV Texture materials (UV_TEX)
-    fast_batch_assign_material_choice(scene, mesh_objects, 'UV_TEX')
+    # Then assign blended Texture + Vertex Colour materials (TEX_VC)
+    fast_batch_assign_material_choice(scene, mesh_objects, 'TEX_VC')
 
 
 def fast_batch_assign_material_choice(scene, mesh_objects, material_choice):


### PR DESCRIPTION
## Summary
- switch world, model, FIN, and PRM imports to end with Tex+VC+Alpha material previews
- add a FIN import helper to batch-assign Tex+VC+Alpha materials via the existing material operator
- update PRM batch assignment to use the blended material choice instead of plain textures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692381faf2c08333b7766205f0dfaef7)