### PR TITLE
Add Tex+VC+Alpha handling to material import/export

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -3294,6 +3294,13 @@ class MaterialAssignmentImportExport(bpy.types.Operator):
             material_choice = 'UV_TEX'  # safe default
         print(f"[DEBUG][IMPEXP] Global material choice: {material_choice}")
 
+        # Texture-based modes require a level texture base to resolve names
+        if material_choice in {"UV_TEX", "TEX_VC", "ENV", "ALPHA"}:
+            if not get_scene_value(scene, "level_texture_base", "").strip():
+                print("[ERROR][IMPEXP] level_texture_base not set; cannot assign texture-based materials")
+                bpy.ops.scene.prompt_texture_base('INVOKE_DEFAULT')
+                return {'CANCELLED'}
+
         existing_textures = self.get_existing_textures()
         print(f"[DEBUG][IMPEXP] Found {len(existing_textures)} existing textures")
 


### PR DESCRIPTION
## Summary
- ensure MaterialAssignmentImportExport checks texture-based modes including Tex+VC+Alpha for required texture base
- prevent texture assignment when level texture base is missing and prompt for user input

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923872612508333bd4e6c1f58155a91)