### PR TITLE
Handle bmesh updates safely outside edit mode

### DIFF
--- a/common.py
+++ b/common.py
@@ -453,26 +453,16 @@ def get_active_face(bm):
 
 
 def get_edit_bmesh(obj):
-	if obj is None or obj.type != 'MESH' or obj.mode != 'EDIT':
-		return None
+        if obj is None or obj.type != 'MESH' or obj.mode != 'EDIT':
+                return None
 
-	bmesh_dic = {}
-
-	try:
-		# Attempt to retrieve the existing bmesh
-		bm = dic[obj.name]
-		bm.faces.layers.int.get("Type")
-		return bm
-
-	except KeyError:
-		# KeyError occurs if obj.name is not in dic - create a new bmesh
-		bm = bmesh.from_edit_mesh(obj.data)
-		dic[obj.name] = bm
-		return bm
-
-	except Exception as e:
-		# Handle other unexpected errors
-		return None
+        try:
+                bm = bmesh.from_edit_mesh(obj.data)
+                bm.faces.layers.int.get("Type")
+                return bm
+        except Exception:
+                # Return None if the edit bmesh is unavailable or invalid
+                return None
 
 
 def apply_trs(obj, bm, transform=False):

--- a/layers.py
+++ b/layers.py
@@ -171,8 +171,19 @@ def update_face_env(self, context):
     
 def update_envmapping(self, context):
     obj = context.object
-    if obj.type == 'MESH':
-        bm = bmesh.from_edit_mesh(obj.data)
+    if obj is None or obj.type != 'MESH':
+        return
+
+    is_edit_mode = obj.mode == 'EDIT'
+
+    if is_edit_mode:
+        try:
+            bm = bmesh.from_edit_mesh(obj.data)
+        except Exception:
+            return
+    else:
+        bm = bmesh.new()
+        bm.from_mesh(obj.data)
 
         # Find or create the _Env material
         base_name, suffix = get_base_name_for_layers(obj)
@@ -202,7 +213,12 @@ def update_envmapping(self, context):
         mat_index = obj.data.materials.find(material.name)
         type_layer = bm.faces.layers.int.get("Type") or bm.faces.layers.int.new("Type")
 
-        bmesh.update_edit_mesh(obj.data)
+        if is_edit_mode:
+            bmesh.update_edit_mesh(obj.data)
+        else:
+            bm.to_mesh(obj.data)
+            bm.free()
+
         obj.data.update()
 
         # Force update the viewport
@@ -210,8 +226,19 @@ def update_envmapping(self, context):
 
 def update_no_envmapping(self, context):
     obj = context.object
-    if obj.type == 'MESH':
-        bm = bmesh.from_edit_mesh(obj.data)
+    if obj is None or obj.type != 'MESH':
+        return
+
+    is_edit_mode = obj.mode == 'EDIT'
+
+    if is_edit_mode:
+        try:
+            bm = bmesh.from_edit_mesh(obj.data)
+        except Exception:
+            return
+    else:
+        bm = bmesh.new()
+        bm.from_mesh(obj.data)
 
         # Find the _Env material
         base_name, suffix = get_base_name_for_layers(obj)
@@ -224,7 +251,12 @@ def update_no_envmapping(self, context):
             mat_index = obj.data.materials.find(material.name)
             type_layer = bm.faces.layers.int.get("Type")
 
-            bmesh.update_edit_mesh(obj.data)
+            if is_edit_mode:
+                bmesh.update_edit_mesh(obj.data)
+            else:
+                bm.to_mesh(obj.data)
+                bm.free()
+
             obj.data.update()
 
             # Force update the viewport


### PR DESCRIPTION
## Summary
- guard environment mapping update callbacks so bmesh operations run safely outside Edit Mode
- simplify edit-mode bmesh retrieval to avoid stale cache lookups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246061e1a883339a1a8d4993c14068)