### PR TITLE
Add texture animation flag support to .m export

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -653,7 +653,7 @@ def register():
     
     bpy.types.Mesh.face_texture_animation = bpy.props.BoolProperty(
         name = "Animated",
-        description = "Uses texture animation for this poly (.w only)",
+        description = "Uses texture animation for this poly (.w and .m files)",
         get=lambda self: bool(get_face_property(self, FACE_TEXANIM)),
         set=lambda self, value: set_face_property(self, value, FACE_TEXANIM)
     )

--- a/m_out.py
+++ b/m_out.py
@@ -111,6 +111,20 @@ def export_mesh(me, obj, scene, filepath, model):
     va_layer = bm.loops.layers.color.get("Alpha") or bm.loops.layers.color.new("Alpha")
     texnum_layer = bm.faces.layers.int.get("Texture Number") or bm.faces.layers.int.new("Texture Number")
     type_layer = bm.faces.layers.int.get("Type") or bm.faces.layers.int.new("Type")
+    custom_type_layers = {}
+    for prop in [
+        "FACE_DOUBLE",
+        "FACE_TRANSLUCENT",
+        "FACE_MIRROR",
+        "FACE_TRANSL_TYPE",
+        "FACE_TEXANIM",
+        "FACE_NOENV",
+        "FACE_ENV",
+        "FACE_CLOTH",
+    ]:
+        layer = bm.faces.layers.int.get(prop)
+        if layer:
+            custom_type_layers[prop] = layer
 
     model.polygon_count += len(bm.faces)
     model.vertex_count += len(bm.verts)
@@ -131,6 +145,9 @@ def export_mesh(me, obj, scene, filepath, model):
         poly = rvstruct.Polygon()
         is_quad = len(face.verts) == 4
         poly.type = face[type_layer] & FACE_PROP_MASK
+        for prop, layer in custom_type_layers.items():
+            if face[layer]:
+                poly.type |= getattr(common, prop)
         if is_quad:
             poly.type |= FACE_QUAD
 


### PR DESCRIPTION
## Summary
- include face flag layers, including texture animation, when exporting .m meshes
- update the face texture animation tooltip to mention .w and .m files

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692465e4e7bc8333b7cdb64fe8090bb2)