### PR TITLE
Handle empty texture animation slots

### DIFF
--- a/texanim.py
+++ b/texanim.py
@@ -54,6 +54,13 @@ def update_ta_current_slot(self, context):
     scene = context.scene
     slot = scene.ta_current_slot
 
+    # If no slots are available, keep the current slot at 0 and exit early to
+    # avoid Blender repeatedly clamping the value and triggering a recursion.
+    if scene.ta_max_slots == 0:
+        if slot != 0:
+            scene.ta_current_slot = 0
+        return
+
     ta = eval(scene.texture_animations)  # Convert string to dictionary
 
     # Ensure the current slot is within bounds


### PR DESCRIPTION
## Summary
- avoid recursion in texture animation slot update when no slots are available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246dc8b778833386f3d4e4fe581240)