### PR TITLE
Fix TexVC naming and car base selection for material toggles

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -2311,6 +2311,13 @@ class MaterialAssignmentHelper:
             print(f"[DEBUG] Using fin_texture_base: {obj['fin_texture_base']} for {obj.name}")
             return obj["fin_texture_base"]
 
+        # Car parts should always derive their base from the selected car texture
+        # instead of the object name (body, wheel, etc.).
+        if self._is_car_part(obj):
+            scene = bpy.context.scene
+            car_tex = get_scene_value(scene, "selected_car_texture", "car.bmp")
+            return clean_model_base_name(car_tex)
+
         model_name = clean_model_base_name(obj.name)
         print(f"[DEBUG] checking model_name={model_name}, obj['is_model']={obj.get('is_model', False)}")
 
@@ -2383,10 +2390,27 @@ class MaterialAssignmentHelper:
             if not orig_mat:
                 continue
 
+            # If the face already uses a TexVC material, keep it as-is so we
+            # don't end up nesting names like "*_TexVC_TexVC" on repeated runs.
+            if self._is_tex_vc_mat(orig_mat):
+                continue
+
             # Base name from the texture material
             base_name = orig_mat.name
             if base_name.lower().endswith('.bmp'):
                 base_name = base_name[:-4]
+            if base_name.endswith('_Col'):
+                # COL-only assignment leaves faces on *_Col; strip that suffix
+                # so TexVC is generated from the texture base again.
+                base_name = base_name[:-4]
+
+            # If the source is a generic utility material (starts with '_') or we
+            # still don't have a usable base, fall back to the object's active
+            # texture base (car, track, etc.) so we don't mint names like
+            # `_Alpha_TexVC` or `_Col_TexVC_TexVC` on repeated toggles.
+            if not base_name or base_name.startswith('_'):
+                base_name = self.get_current_base_name(obj)
+
             new_name = f"{base_name}_TexVC"
 
             new_mat = blended_cache.get(new_name)
@@ -3077,7 +3101,7 @@ class MaterialAssignmentHelper:
     def assign_regular_materials(self, obj, material_suffix):
         print(f"[FAST] assign_regular_materials: {obj.name}")
 
-        base_name = clean_model_base_name(obj.name, truncate=False)
+        base_name = self.get_current_base_name(obj)
         potential_names = [
             f"{base_name}{material_suffix}",
             f"{base_name}.prm{material_suffix}",
@@ -3286,6 +3310,11 @@ class MaterialAssignment(bpy.types.Operator):
         if obj.get("is_instance") and "fin_texture_base" in obj:
             return obj["fin_texture_base"]
 
+        if self._is_car_part(obj):
+            scene = bpy.context.scene
+            car_tex = get_scene_value(scene, "selected_car_texture", "car.bmp")
+            return clean_model_base_name(car_tex)
+
         model_name = clean_model_base_name(obj.name)
 
         if obj.get("is_model", False):
@@ -3478,7 +3507,7 @@ class MaterialAssignment(bpy.types.Operator):
         obj.data.update()
 
     def assign_regular_materials(self, obj, material_suffix):
-        base_name = clean_model_base_name(obj.name, truncate=False)
+        base_name = self.get_current_base_name(obj)
 
         potential_names = [
             f"{base_name}{material_suffix}",
@@ -3623,6 +3652,11 @@ class MaterialAssignmentImportExport(bpy.types.Operator):
         if obj.get("is_instance") and "fin_texture_base" in obj:
             print(f"[DEBUG] Using fin_texture_base: {obj['fin_texture_base']} for {obj.name}")
             return obj["fin_texture_base"]
+
+        if self._is_car_part(obj):
+            scene = bpy.context.scene
+            car_tex = get_scene_value(scene, "selected_car_texture", "car.bmp")
+            return clean_model_base_name(car_tex)
 
         model_name = clean_model_base_name(obj.name)
         print(f"[DEBUG] checking model_name={model_name}, obj['is_model']={obj.get('is_model', False)}")
@@ -3853,7 +3887,7 @@ class MaterialAssignmentImportExport(bpy.types.Operator):
         obj.data.update()
 
     def assign_regular_materials(self, obj, material_suffix):
-        base_name = clean_model_base_name(obj.name, truncate=False)
+        base_name = self.get_current_base_name(obj)
 
         potential_names = [
             f"{base_name}{material_suffix}",


### PR DESCRIPTION
## Summary
- prevent TexVC generation from using underscore utility materials as base names, keeping car blends on the active texture
- derive regular material assignment bases from the active object texture (including car textures) instead of the raw object name

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948146bc7e0833399653aef0396cbc4)