### PR TITLE
Sync UI UVs before Transform Animation

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -5865,6 +5865,10 @@ class TexAnimTransform(bpy.types.Operator):
         if frame_end < frame_start:
             frame_start, frame_end = frame_end, frame_start
 
+        current_frame = scene.ta_current_frame
+        if current_frame in (frame_start, frame_end):
+            sync_ui_uvs_to_frame(scene, ta, slot, current_frame)
+
         # Shortcut: if start == end, nothing to interpolate – just ensure delay/texture are set
         if frame_start == frame_end:
             idx = frame_start

--- a/texanim.py
+++ b/texanim.py
@@ -155,6 +155,23 @@ def update_ta_current_frame_uv(context, ui_index):
 
     scene.texture_animations = str(ta)
 
+def sync_ui_uvs_to_frame(scene, ta, slot, frame):
+    """Sync current UI UVs into the specified TA frame (allocation-safe)."""
+    needed = max(int(scene.ta_max_frames), int(frame) + 1)
+    ensure_slot_frames(ta, slot, needed)
+
+    ui_uv = [
+        scene.ta_current_frame_uv0,
+        scene.ta_current_frame_uv1,
+        scene.ta_current_frame_uv2,
+        scene.ta_current_frame_uv3,
+    ]
+
+    for ui_index, (u, v_ui) in enumerate(ui_uv):
+        stored_index = 3 - ui_index
+        ta[slot]["frames"][frame]["uv"][stored_index]["u"] = float(u)
+        ta[slot]["frames"][frame]["uv"][stored_index]["v"] = 1.0 - float(v_ui)
+
 def copy_uv_to_frame(context):
     scene = context.scene
     obj = context.object


### PR DESCRIPTION
### Motivation
- Prevent transform interpolation from using stale or default 0.0 UVs when the UI has edited UVs that were not yet written into the stored texture animation frame.

### Description
- Add `sync_ui_uvs_to_frame(scene, ta, slot, frame)` in `texanim.py` which allocates frames if needed and writes the current UI UV props into the specified stored TA frame using the correct UI->stored index mapping. 
- Call `sync_ui_uvs_to_frame` from the `TexAnimTransform` operator in `operators.py` when the scene `ta_current_frame` equals the transform `frame_start` or `frame_end`, so UI changes are persisted before interpolation begins. 
- Keep allocation guards by using the existing `ensure_slot_frames` helper to avoid index errors when writing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ddfe627588333a94c3ad1f03d8ce5)