### PR TITLE
Sync transform UVs from active face

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -5865,6 +5865,12 @@ class TexAnimTransform(bpy.types.Operator):
         if frame_end < frame_start:
             frame_start, frame_end = frame_end, frame_start
 
+        current_frame = scene.ta_current_frame
+        if current_frame in (frame_start, frame_end):
+            updated = sync_frame_uvs_from_mesh(context, ta, slot, current_frame)
+            if not updated:
+                sync_ui_uvs_to_frame(scene, ta, slot, current_frame)
+
         # Shortcut: if start == end, nothing to interpolate – just ensure delay/texture are set
         if frame_start == frame_end:
             idx = frame_start

--- a/texanim.py
+++ b/texanim.py
@@ -155,6 +155,62 @@ def update_ta_current_frame_uv(context, ui_index):
 
     scene.texture_animations = str(ta)
 
+def sync_ui_uvs_to_frame(scene, ta, slot, frame):
+    """Sync current UI UVs into the specified TA frame (allocation-safe)."""
+    needed = max(int(scene.ta_max_frames), int(frame) + 1)
+    ensure_slot_frames(ta, slot, needed)
+
+    ui_uv = [
+        scene.ta_current_frame_uv0,
+        scene.ta_current_frame_uv1,
+        scene.ta_current_frame_uv2,
+        scene.ta_current_frame_uv3,
+    ]
+
+    for ui_index, (u, v_ui) in enumerate(ui_uv):
+        stored_index = 3 - ui_index
+        ta[slot]["frames"][frame]["uv"][stored_index]["u"] = float(u)
+        ta[slot]["frames"][frame]["uv"][stored_index]["v"] = 1.0 - float(v_ui)
+
+def sync_frame_uvs_from_mesh(context, ta, slot, frame):
+    """Sync UVs from the active edit-mode face into the specified TA frame."""
+    obj = context.object
+    if not obj or obj.type != 'MESH' or obj.mode != 'EDIT':
+        return False
+
+    bm = get_edit_bmesh(obj)
+    if not bm:
+        return False
+
+    uv_layer = bm.loops.layers.uv.active
+    if not uv_layer:
+        return False
+
+    face = get_active_face(bm)
+    if not face:
+        selected_faces = [f for f in bm.faces if f.select]
+        if not selected_faces:
+            return False
+        face = selected_faces[0]
+
+    loops = list(face.loops)
+    if len(loops) != 4:
+        return False
+
+    needed = max(int(context.scene.ta_max_frames), int(frame) + 1)
+    ensure_slot_frames(ta, slot, needed)
+
+    # UI0<-loop3, UI1<-loop2, UI2<-loop1, UI3<-loop0
+    loop_to_ui = {3: 0, 2: 1, 1: 2, 0: 3}
+
+    for loop_index, ui_index in loop_to_ui.items():
+        uv = loops[loop_index][uv_layer].uv
+        stored_index = 3 - ui_index
+        ta[slot]["frames"][frame]["uv"][stored_index]["u"] = float(uv.x)
+        ta[slot]["frames"][frame]["uv"][stored_index]["v"] = 1.0 - float(uv.y)
+
+    return True
+
 def copy_uv_to_frame(context):
     scene = context.scene
     obj = context.object

--- a/texanim.py
+++ b/texanim.py
@@ -187,6 +187,8 @@ def sync_frame_uvs_from_mesh(context, ta, slot, frame):
         return False
 
     face = get_active_face(bm)
+    if not face and hasattr(bm.faces, "active"):
+        face = bm.faces.active
     if not face:
         selected_faces = [f for f in bm.faces if f.select]
         if not selected_faces:


### PR DESCRIPTION
### Motivation
- Fix incorrect or stale UVs being used during transform interpolation by reading UV coordinates directly from the active edit-mode quad face when available. 
- Address cases where corner UVs appear duplicated/mis-mapped by applying an explicit loop->UI index mapping when writing stored texture-animation frames.

### Description
- Add `sync_frame_uvs_from_mesh(context, ta, slot, frame)` in `texanim.py` to read UVs from the active edit-mode face (quads only), map loops to UI indices via `loop_to_ui = {3: 0, 2: 1, 1: 2, 0: 3}`, and write into the stored TA frame with the same `1.0 - v` conversion used by the UI. 
- Add `sync_ui_uvs_to_frame(scene, ta, slot, frame)` (allocation-safe) to explicitly persist UI UV properties into a TA frame and keep `update_ta_current_frame_uv` behavior intact. 
- Update `TexAnimTransform` in `operators.py` to attempt `sync_frame_uvs_from_mesh` when the current frame equals the transform `frame_start` or `frame_end`, and fall back to `sync_ui_uvs_to_frame` when mesh data is not available, while ensuring frames are allocated with `ensure_slot_frames` and bounds-checked. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ddfe627588333a94c3ad1f03d8ce5)